### PR TITLE
Added an option to remove the libraries section from the home screen

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -126,7 +126,10 @@ export default function Home() {
                     width: "100%",
                     height: "auto",
                     aspectRatio: "16/9",
-                    display: "flex",
+                    display: 
+                      settings["DISABLE_HOME_SCREEN_LIBRARIES"] === "true"
+                        ? "none"
+                        : "flex",
                     alignItems: "center",
                     justifyContent: "center",
                     borderRadius: "7px",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import SettingsPlayback from "./settings/SettingsPlayback";
 import { useUserSettings } from "../states/UserSettingsState";
 import SettingsRecommendations from "./settings/SettingsRecommendations";
 import SettingsLibraries from "./settings/SettingsLibraries";
+import SettingsHome from "./settings/SettingsHome";
 
 function Settings() {
   const { loaded } = useUserSettings();
@@ -53,11 +54,12 @@ function Settings() {
       >
         <SettingsDivider title="General" />
         <SettingsItem title="About" link="/settings/info" />
-
         <SettingsDivider title="Experience" />
         <SettingsItem title="Playback" link="/settings/experience-playback" />
         <SettingsItem title="Recommendations" link="/settings/experience-recommendations" />
         <SettingsItem title="Libraries" link="/settings/experience-libraries" />
+        <SettingsDivider title="UI" />
+        <SettingsItem title="Home" link="/settings/experience-home" />
       </Box>
 
       <Box
@@ -81,6 +83,7 @@ function Settings() {
           <Route path="/experience-playback" element={<SettingsPlayback />} />
           <Route path="/experience-recommendations" element={<SettingsRecommendations />} />
           <Route path="/experience-libraries" element={<SettingsLibraries />} />
+          <Route path="/experience-home" element={<SettingsHome />} />
         </Routes>
       </Box>
     </Box>

--- a/frontend/src/pages/settings/SettingsHome.tsx
+++ b/frontend/src/pages/settings/SettingsHome.tsx
@@ -1,0 +1,41 @@
+import { Typography, Box } from "@mui/material";
+import React from "react";
+import CheckBoxOption from "../../components/settings/CheckBoxOption";
+import { useUserSettings } from "../../states/UserSettingsState";
+
+function SettingsHome() {
+  const { settings, setSetting } = useUserSettings();
+
+  return (
+    <>
+      <Typography variant="h4">Experience - Home</Typography>
+
+      <Box
+        sx={{
+          mt: 2,
+          width: "100%",
+          height: "40px",
+          backgroundColor: "#181818",
+          borderRadius: "10px",
+        }}
+      />
+
+      <Box sx={{ mt: 2, display: "flex", gap: 2, width: "50%" }}>
+        <CheckBoxOption
+          title="Disable Home Libraries Section"
+          subtitle="Disables the section on the home screen where the libraries are displayed."
+          checked={settings.DISABLE_HOME_SCREEN_LIBRARIES === "true"}
+          onChange={() => {
+            setSetting(
+              "DISABLE_HOME_SCREEN_LIBRARIES",
+              settings["DISABLE_HOME_SCREEN_LIBRARIES"] === "true"
+                ? "false"
+                : "true"
+            );
+          }}
+        />
+      </Box>
+    </>
+  );
+}
+export default SettingsHome;

--- a/frontend/src/states/UserSettingsState.ts
+++ b/frontend/src/states/UserSettingsState.ts
@@ -4,6 +4,7 @@ import { getBackendURL } from '../backendURL';
 
 type UserSettingsOptions = 
 "DISABLE_WATCHSCREEN_DARKENING" |
+"DISABLE_HOME_SCREEN_LIBRARIES" |
 "AUTO_MATCH_TRACKS" |
 "AUTO_NEXT_EP" |
 string;
@@ -21,6 +22,7 @@ export const useUserSettings = create<UserSettingsState>((set) => ({
     loaded: false,
     settings: {
         DISABLE_WATCHSCREEN_DARKENING: "false",
+        DISABLE_HOME_SCREEN_LIBRARIES: "false",
         AUTO_MATCH_TRACKS: "true",
         AUTO_NEXT_EP: "true",
     },


### PR DESCRIPTION
An option to remove the libraries section from the home screen as it is redundant with the top nav. I made a new UI section in the settings page, it may or may not be the most organized idea, let me know!